### PR TITLE
fix(alias): BSD sed에서 alias-list 동작하도록 수정

### DIFF
--- a/shell/setup-alias/setup-aliases.sh
+++ b/shell/setup-alias/setup-aliases.sh
@@ -20,7 +20,7 @@ MARKER_END="# <<< https://jeongph.dev/handy/setup-alias <<<"
 # 항상 포함되는 alias (이름|값)
 ALWAYS_ALIASES=(
     "alias-fetch|source <(curl -fsSL https://jeongph.dev/handy/setup-alias)"
-    'alias-list|sed -n "/^# >>>/,/^# <<</{ /^alias /p }" "$HOME/.$(basename $SHELL)rc" 2>/dev/null'
+    'alias-list|sed -n "/^# >>>/,/^# <<</{ /^alias /p; }" "$HOME/.$(basename $SHELL)rc" 2>/dev/null'
 )
 
 # 카테고리|이름|값


### PR DESCRIPTION
## 배경
`alias-list` 가 macOS 에서는 아무것도 출력하지 않고 Linux(Ubuntu)에서만 동작하던 문제.

## 원인
BSD sed(macOS)는 `{ ... }` 블록 안에서 명령 뒤에 세미콜론/줄바꿈을 요구한다. 기존 `{ /^alias /p }` 는 `extra characters at the end of p command` 에러로 실패했고, GNU sed(Linux)에서만 동작했다. 게다가 정의 끝의 `2>/dev/null` 이 에러를 가려 macOS 에서는 "빈 출력"으로 보였다.

## 수정
`p }` → `p; }` 로 변경. `;` 는 GNU/BSD sed 양쪽 표준이라 Linux 동작도 그대로 유지된다.

## 검증
- macOS(BSD sed)에서 `alias-list` 가 alias 20개를 정상 출력함을 확인
- `;` 는 GNU sed 에서도 표준이므로 기존 Linux 동작 유지
