### PR TITLE
fix(setup-alias): zsh에서 alias 설치가 통째로 실패하던 버그 수정

### DIFF
--- a/shell/setup-alias/setup-alias.sh
+++ b/shell/setup-alias/setup-alias.sh
@@ -18,11 +18,14 @@ MARKER_BEGIN="# >>> https://handy.jeongph.dev/setup-alias >>>"
 MARKER_END="# <<< https://handy.jeongph.dev/setup-alias <<<"
 
 # 레거시 마커 (구 URL로 설치된 블록 — 재설치/제거 시 함께 청소하여 자동 마이그레이션)
+# 세대별로 URL/파일명이 바뀌었으므로 과거 마커를 모두 나열한다 (BEGIN/END 인덱스 대응)
 LEGACY_MARKER_BEGIN=(
     "# >>> https://jeongph.dev/handy/setup-alias >>>"
+    "# >>> https://jeongph.dev/handy/setup-aliases.sh >>>"
 )
 LEGACY_MARKER_END=(
     "# <<< https://jeongph.dev/handy/setup-alias <<<"
+    "# <<< https://jeongph.dev/handy/setup-aliases.sh <<<"
 )
 
 # 항상 포함되는 alias (이름|값)
@@ -139,8 +142,9 @@ remove_block() {
     # 신 마커 블록 제거
     remove_marker_block "$rc_file" "$MARKER_BEGIN" "$MARKER_END"
     # 레거시 마커 블록도 제거 (구 URL → 신 URL 자동 마이그레이션)
+    # 인덱스 순회는 C-style로 — zsh는 bash의 ${!arr[@]}를 지원하지 않아 bad substitution이 난다
     local i
-    for i in "${!LEGACY_MARKER_BEGIN[@]}"; do
+    for ((i=0; i<${#LEGACY_MARKER_BEGIN[@]}; i++)); do
         remove_marker_block "$rc_file" "${LEGACY_MARKER_BEGIN[$i]}" "${LEGACY_MARKER_END[$i]}"
     done
 }


### PR DESCRIPTION
## 배경

macOS(기본 셸 zsh)에서 `source <(curl -fsSL https://handy.jeongph.dev/setup-alias)`로 설치해도 `~/.zshrc`에 alias가 하나도 추가되지 않는 문제 제보.

## 원인

`remove_block()`이 bash 전용 문법 `${!LEGACY_MARKER_BEGIN[@]}`(배열 인덱스 확장)를 사용한다. zsh는 이 문법을 지원하지 않아 **`bad substitution`으로 스크립트가 중단**된다. 이 호출이 블록을 파일에 기록하기 **직전**에 있어, zsh에서는 설치/업데이트/제거 모든 경로가 기록 전에 죽어 `.zshrc`에 아무것도 남지 않았다.

부수적으로, 레거시 마커 목록에 1세대 마커(`setup-aliases.sh`)가 빠져 있어 가장 오래된 URL로 설치된 블록은 `--remove`/재설치 시 감지되지 않았다.

두 문제 모두 `338e3e1`(레거시 마커 자동 마이그레이션 추가)에서 유입됐다.

## 변경

- `${!arr[@]}` → C-style 인덱스 루프(`for ((i=0; ...))`)로 교체 — bash/zsh 양쪽 호환
- 레거시 마커 목록에 1세대(`setup-aliases.sh`) 추가

## 검증

bash + zsh 5.9 실측:

- [x] `bash -n` / `zsh -n` 문법 통과
- [x] clean install (`--all`) — bash/zsh 각 25개 기록
- [x] clean install (zsh 대화형 TUI, `source`) — 25개 기록
- [x] Gen-1 블록 존재 시 재설치 마이그레이션 — Gen-1 제거·신규 기록, 사용자 설정 보존
- [x] `--remove` end-to-end — 마커/alias 0

## 참고 (레포 밖 인프라, 별도 처리 필요)

- 구 URL `jeongph.dev/handy/*`가 **HTTP 526** 반환 — 과거 `alias-fetch`가 여기 물려 있으면 동작 불가
- 현재 배포가 문서의 allowlist Worker가 아니라 와일드카드 Redirect Rule이라 경로 순회가 통과 (#9)